### PR TITLE
repackage node libs during renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "schedule": "before 4am"
   },
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+  "postUpgradeTasks": { "commands": ["(cd ./actions/installer && make clean && make package)"] },
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
renovate-bot won't automatically re-ccompile the `dist` folders after bumping versionsin package.json and package-lock.json

This PR attempts to add an additional instruction to renovate-bot to do `(cd ./actions/installer && make clean && make package)` .

## Testing

I have not found a reliable way to test, other than first merging, and then